### PR TITLE
Update travis for updated command style of scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - gem install scan
 
 script:
-  - scan
+  - fastlane scan
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Based on the following command running output:
`sudo gem install scan`
```
Fetching: scan-1.0.0.gem (100%)
Please use `fastlane scan` instead of `scan` from now on.
Successfully installed scan-1.0.0
Parsing documentation for scan-1.0.0
Installing ri documentation for scan-1.0.0
Done installing documentation for scan after 0 seconds
1 gem installed
```